### PR TITLE
SDFSOF-121 - Updated logic to use lastUpdatedAt instead of createdAt

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/custody/CustodyPayment.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/custody/CustodyPayment.java
@@ -34,7 +34,7 @@ public class CustodyPayment {
   String assetIssuer;
   String assetName;
 
-  Instant createdAt;
+  Instant updatedAt;
   CustodyPaymentStatus status;
   String message;
 
@@ -46,7 +46,7 @@ public class CustodyPayment {
   public static CustodyPayment fromPayment(
       Optional<PaymentOperationResponse> paymentOperation,
       String externalTxId,
-      Instant createdAt,
+      Instant updatedAt,
       CustodyPaymentStatus status,
       String message,
       String transactionHash)
@@ -106,7 +106,7 @@ public class CustodyPayment {
         .assetCode(assetCode)
         .assetIssuer(assetIssuer)
         .assetName(assetName)
-        .createdAt(createdAt)
+        .updatedAt(updatedAt)
         .status(status)
         .message(message)
         .transactionHash(transactionHash)
@@ -119,7 +119,7 @@ public class CustodyPayment {
   public static CustodyPayment fromPathPayment(
       Optional<PathPaymentBaseOperationResponse> pathPaymentOperation,
       String externalTxId,
-      Instant createdAt,
+      Instant updatedAt,
       CustodyPaymentStatus status,
       String message,
       String transactionHash)
@@ -179,7 +179,7 @@ public class CustodyPayment {
         .assetCode(assetCode)
         .assetIssuer(assetIssuer)
         .assetName(assetName)
-        .createdAt(createdAt)
+        .updatedAt(updatedAt)
         .status(status)
         .message(message)
         .transactionHash(transactionHash)

--- a/platform/src/main/java/org/stellar/anchor/platform/custody/CustodyPaymentHandler.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/custody/CustodyPaymentHandler.java
@@ -1,6 +1,5 @@
 package org.stellar.anchor.platform.custody;
 
-import static org.stellar.anchor.api.sep.SepTransactionStatus.ERROR;
 import static org.stellar.anchor.platform.custody.CustodyPayment.CustodyPaymentStatus.SUCCESS;
 import static org.stellar.anchor.platform.data.CustodyTransactionStatus.COMPLETED;
 import static org.stellar.anchor.platform.data.CustodyTransactionStatus.FAILED;
@@ -57,7 +56,7 @@ public abstract class CustodyPaymentHandler {
       throws AnchorException, IOException;
 
   protected void updateTransaction(JdbcCustodyTransaction txn, CustodyPayment payment) {
-    txn.setUpdatedAt(payment.getCreatedAt());
+    txn.setUpdatedAt(payment.getUpdatedAt());
     txn.setFromAccount(payment.getFrom());
     txn.setExternalTxId(payment.getExternalTxId());
     txn.setStatus(getCustodyTransactionStatus(payment.getStatus()).toString());

--- a/platform/src/main/java/org/stellar/anchor/platform/custody/fireblocks/FireblocksEventService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/custody/fireblocks/FireblocksEventService.java
@@ -150,7 +150,7 @@ public class FireblocksEventService extends CustodyEventService {
             CustodyPayment.fromPayment(
                 Optional.empty(),
                 td.getId(),
-                Instant.ofEpochMilli(td.getCreatedAt()),
+                Instant.ofEpochMilli(td.getLastUpdated()),
                 status,
                 message,
                 td.getTxHash());
@@ -160,7 +160,7 @@ public class FireblocksEventService extends CustodyEventService {
             CustodyPayment.fromPayment(
                 Optional.of(paymentOperation),
                 td.getId(),
-                Instant.ofEpochMilli(td.getCreatedAt()),
+                Instant.ofEpochMilli(td.getLastUpdated()),
                 status,
                 message,
                 td.getTxHash());
@@ -171,7 +171,7 @@ public class FireblocksEventService extends CustodyEventService {
             CustodyPayment.fromPathPayment(
                 Optional.of(pathPaymentOperation),
                 td.getId(),
-                Instant.ofEpochMilli(td.getCreatedAt()),
+                Instant.ofEpochMilli(td.getLastUpdated()),
                 status,
                 message,
                 td.getTxHash());

--- a/platform/src/test/resources/custody/fireblocks/webhook/completed_event_no_stellar_txn_payment.json
+++ b/platform/src/test/resources/custody/fireblocks/webhook/completed_event_no_stellar_txn_payment.json
@@ -1,7 +1,7 @@
 {
   "externalTxId": "testEventId",
   "type": "payment",
-  "createdAt": "2023-05-10T10:18:25.778Z",
+  "updatedAt": "2023-05-10T10:18:26.130Z",
   "status": "SUCCESS",
   "transactionHash": "testTxHash"
 }

--- a/platform/src/test/resources/custody/fireblocks/webhook/failed_event_no_stellar_txn_payment.json
+++ b/platform/src/test/resources/custody/fireblocks/webhook/failed_event_no_stellar_txn_payment.json
@@ -1,7 +1,7 @@
 {
   "externalTxId": "testEventId",
   "type": "payment",
-  "createdAt": "2023-05-10T10:18:25.778Z",
+  "updatedAt": "2023-05-10T10:18:26.130Z",
   "status": "ERROR",
   "transactionHash": "testTxHash",
   "message": "THIRD_PARTY_FAILED"

--- a/platform/src/test/resources/custody/fireblocks/webhook/handler/custody_payment_with_id.json
+++ b/platform/src/test/resources/custody/fireblocks/webhook/handler/custody_payment_with_id.json
@@ -7,7 +7,7 @@
   "amount": "1.0000000",
   "assetType": "credit_alphanum4",
   "assetName": "testAmountInAsset",
-  "createdAt": "2023-05-10T10:18:25.778Z",
+  "updatedAt": "2023-05-10T10:18:25.778Z",
   "status": "SUCCESS",
   "transactionHash": "testTxHash",
   "transactionMemoType": "none",

--- a/platform/src/test/resources/custody/fireblocks/webhook/handler/custody_payment_with_id_error.json
+++ b/platform/src/test/resources/custody/fireblocks/webhook/handler/custody_payment_with_id_error.json
@@ -7,7 +7,7 @@
   "amount": "1.0000000",
   "assetType": "credit_alphanum4",
   "assetName": "testAmountInAsset",
-  "createdAt": "2023-05-10T10:18:25.778Z",
+  "updatedAt": "2023-05-10T10:18:25.778Z",
   "status": "ERROR",
   "transactionHash": "testTxHash",
   "transactionMemoType": "none",

--- a/platform/src/test/resources/custody/fireblocks/webhook/stellar_txn_path_payment.json
+++ b/platform/src/test/resources/custody/fireblocks/webhook/stellar_txn_path_payment.json
@@ -8,7 +8,7 @@
   "assetType": "native",
   "assetCode": "native",
   "assetName": "native",
-  "createdAt": "2023-05-10T10:18:25.778Z",
+  "updatedAt": "2023-05-10T10:18:26.130Z",
   "status": "SUCCESS",
   "transactionHash": "testTxHash",
   "transactionMemoType": "none",

--- a/platform/src/test/resources/custody/fireblocks/webhook/stellar_txn_payment.json
+++ b/platform/src/test/resources/custody/fireblocks/webhook/stellar_txn_payment.json
@@ -8,7 +8,7 @@
   "assetType": "native",
   "assetCode": "native",
   "assetName": "native",
-  "createdAt": "2023-05-10T10:18:25.778Z",
+  "updatedAt": "2023-05-10T10:18:26.130Z",
   "status": "SUCCESS",
   "transactionHash": "testTxHash",
   "transactionMemoType": "none",


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Fixed an issue that custody_transaction's updated_at timestamp might be updated back in time

### Why

updated_at should contain the last update at timestamp

### Known limitations

[TODO or N/A]