### PR TITLE
SDFSOF-134: Custody_refunds: do_stellar_refund action triggers a payment the ignores refund object params, making a payment of amount)expected value instead

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/custody/CreateCustodyTransactionRequest.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/custody/CreateCustodyTransactionRequest.java
@@ -17,5 +17,4 @@ public class CreateCustodyTransactionRequest {
   private String amountFee;
   private String asset;
   private String kind;
-  private String type;
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyTransactionController.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/controller/custody/CustodyTransactionController.java
@@ -1,5 +1,7 @@
 package org.stellar.anchor.platform.controller.custody;
 
+import static org.stellar.anchor.platform.data.JdbcCustodyTransaction.PaymentType.PAYMENT;
+
 import lombok.SneakyThrows;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -31,7 +33,7 @@ public class CustodyTransactionController {
       value = "/transactions",
       method = {RequestMethod.POST})
   public void createCustodyTransaction(@RequestBody CreateCustodyTransactionRequest request) {
-    custodyTransactionService.create(request);
+    custodyTransactionService.create(request, PAYMENT);
   }
 
   @SneakyThrows

--- a/platform/src/main/java/org/stellar/anchor/platform/custody/CustodyTransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/custody/CustodyTransactionService.java
@@ -25,6 +25,7 @@ import org.stellar.anchor.api.exception.custody.CustodyServiceUnavailableExcepti
 import org.stellar.anchor.api.exception.custody.CustodyTooManyRequestsException;
 import org.stellar.anchor.platform.data.CustodyTransactionStatus;
 import org.stellar.anchor.platform.data.JdbcCustodyTransaction;
+import org.stellar.anchor.platform.data.JdbcCustodyTransaction.PaymentType;
 import org.stellar.anchor.platform.data.JdbcCustodyTransactionRepo;
 
 public abstract class CustodyTransactionService {
@@ -48,7 +49,7 @@ public abstract class CustodyTransactionService {
    * @param request custody transaction info
    * @return {@link JdbcCustodyTransaction} object
    */
-  public JdbcCustodyTransaction create(CreateCustodyTransactionRequest request)
+  public JdbcCustodyTransaction create(CreateCustodyTransactionRequest request, PaymentType type)
       throws CustodyBadRequestException {
     validateRequest(request);
 
@@ -67,7 +68,7 @@ public abstract class CustodyTransactionService {
             .asset(request.getAsset())
             .kind(request.getKind())
             .reconciliationAttemptCount(0)
-            .type(PAYMENT.getType())
+            .type(type.getType())
             .build());
   }
 
@@ -146,8 +147,8 @@ public abstract class CustodyTransactionService {
             .amountFee(refundRequest.getAmountFee())
             .asset(txn.getAsset())
             .kind(txn.getKind())
-            .type(REFUND.getType())
-            .build());
+            .build(),
+        REFUND);
   }
 
   private void updateCustodyTransaction(

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/custody/CustodyTransactionServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/custody/CustodyTransactionServiceTest.kt
@@ -65,7 +65,7 @@ class CustodyTransactionServiceTest {
 
     every { custodyTransactionRepo.save(capture(entityCapture)) } returns null
 
-    custodyTransactionService.create(request)
+    custodyTransactionService.create(request, PAYMENT)
 
     val actualCustodyTransaction = entityCapture.captured
     assertTrue(!Instant.now().isBefore(actualCustodyTransaction.createdAt))
@@ -89,7 +89,9 @@ class CustodyTransactionServiceTest {
     request.memo = "YzRhMDgzNWItYjFmYy00NDZlLTkzYTUtMTFlYzhiZTk="
 
     val exception =
-      assertThrows<CustodyBadRequestException> { custodyTransactionService.create(request) }
+      assertThrows<CustodyBadRequestException> {
+        custodyTransactionService.create(request, PAYMENT)
+      }
     Assertions.assertEquals(
       "Memo type [hash] is not supported by Fireblocks custody service",
       exception.message


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Custody transaction payment type fix

### Why

Refund custody transaction has invalid payment type

### Known limitations

[TODO or N/A]