### PR TITLE
SDFSOF-134: Custody_refunds: do_stellar_refund action triggers a payment the ignores refund object params, making a payment of amount)expected value instead

### DIFF
--- a/platform/src/main/java/org/stellar/anchor/platform/custody/CustodyTransactionService.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/custody/CustodyTransactionService.java
@@ -123,7 +123,7 @@ public abstract class CustodyTransactionService {
 
     CreateTransactionPaymentResponse response;
     try {
-      response = custodyPaymentService.createTransactionPayment(txn, null);
+      response = custodyPaymentService.createTransactionPayment(refundTxn, null);
       updateCustodyTransaction(refundTxn, response.getId(), SUBMITTED);
     } catch (FireblocksException e) {
       custodyTransactionRepo.deleteById(refundTxn.getId());

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/custody/CustodyTransactionServiceTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/custody/CustodyTransactionServiceTest.kt
@@ -248,6 +248,8 @@ class CustodyTransactionServiceTest {
         getResourceFileAsString("service/custodyTransaction/custody_transaction_payment.json"),
         JdbcCustodyTransaction::class.java
       )
+    val refundTransaction = JdbcCustodyTransaction()
+    refundTransaction.id = REFUND_TRANSACTION_ID
     val custodyTxCapture = slot<JdbcCustodyTransaction>()
 
     every {
@@ -256,11 +258,11 @@ class CustodyTransactionServiceTest {
         PAYMENT.type
       )
     } returns transaction
-    every { custodyTransactionRepo.save(capture(custodyTxCapture)) } returns transaction
+    every { custodyTransactionRepo.save(capture(custodyTxCapture)) } returns refundTransaction
 
     custodyTransactionService.createRefund(TRANSACTION_ID, request)
 
-    verify(exactly = 1) { custodyPaymentService.createTransactionPayment(transaction, null) }
+    verify(exactly = 1) { custodyPaymentService.createTransactionPayment(refundTransaction, null) }
   }
 
   @Test
@@ -281,7 +283,7 @@ class CustodyTransactionServiceTest {
       )
     } returns transaction
     every { custodyTransactionRepo.save(any()) } returns refundTransaction
-    every { custodyPaymentService.createTransactionPayment(transaction, null) } throws
+    every { custodyPaymentService.createTransactionPayment(refundTransaction, null) } throws
       FireblocksException("Bad request", 400)
 
     val ex =
@@ -311,7 +313,7 @@ class CustodyTransactionServiceTest {
       )
     } returns transaction
     every { custodyTransactionRepo.save(any()) } returns refundTransaction
-    every { custodyPaymentService.createTransactionPayment(transaction, null) } throws
+    every { custodyPaymentService.createTransactionPayment(refundTransaction, null) } throws
       FireblocksException("Too many requests", 429)
 
     val ex =
@@ -341,7 +343,7 @@ class CustodyTransactionServiceTest {
       )
     } returns transaction
     every { custodyTransactionRepo.save(any()) } returns refundTransaction
-    every { custodyPaymentService.createTransactionPayment(transaction, null) } throws
+    every { custodyPaymentService.createTransactionPayment(refundTransaction, null) } throws
       FireblocksException("Service unavailable", 503)
 
     val ex =
@@ -371,7 +373,7 @@ class CustodyTransactionServiceTest {
       )
     } returns transaction
     every { custodyTransactionRepo.save(any()) } returns refundTransaction
-    every { custodyPaymentService.createTransactionPayment(transaction, null) } throws
+    every { custodyPaymentService.createTransactionPayment(refundTransaction, null) } throws
       FireblocksException("Forbidden", 403)
 
     val ex =


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Custody transaction refund fix

### Why

Custody transaction refund is created incorrectly

### Known limitations

[TODO or N/A]