### PR TITLE
SDFSOF-133: Add validaton to MEMO types for specific providers

### DIFF
--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -37,7 +37,6 @@ import org.stellar.anchor.api.exception.SepException;
 import org.stellar.anchor.api.exception.SepNotAuthorizedException;
 import org.stellar.anchor.api.exception.SepNotFoundException;
 import org.stellar.anchor.api.exception.SepValidationException;
-import org.stellar.anchor.api.exception.rpc.InvalidParamsException;
 import org.stellar.anchor.api.sep.AssetInfo;
 import org.stellar.anchor.api.sep.sep24.DepositTransactionResponse;
 import org.stellar.anchor.api.sep.sep24.GetTransactionRequest;
@@ -203,7 +202,7 @@ public class Sep24Service {
 
       if (!CustodyUtils.isMemoTypeSupported(
           custodyConfig.getType(), memoTypeString(memoType(memo)))) {
-        throw new InvalidParamsException(
+        throw new SepValidationException(
             String.format(
                 "Memo type[%s] is not supported for custody type[%s]",
                 memoTypeString(memoType(memo)), custodyConfig.getType()));
@@ -218,7 +217,7 @@ public class Sep24Service {
 
       if (!CustodyUtils.isMemoTypeSupported(
           custodyConfig.getType(), memoTypeString(memoType(refundMemo)))) {
-        throw new InvalidParamsException(
+        throw new SepValidationException(
             String.format(
                 "Refund memo type[%s] is not supported for custody type[%s]",
                 memoTypeString(memoType(refundMemo)), custodyConfig.getType()));

--- a/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
+++ b/core/src/main/java/org/stellar/anchor/sep24/Sep24Service.java
@@ -2,11 +2,16 @@ package org.stellar.anchor.sep24;
 
 import static org.stellar.anchor.api.event.AnchorEvent.Type.TRANSACTION_CREATED;
 import static org.stellar.anchor.api.sep.SepTransactionStatus.INCOMPLETE;
-import static org.stellar.anchor.api.sep.sep24.InfoResponse.*;
+import static org.stellar.anchor.api.sep.sep24.InfoResponse.FeatureFlagResponse;
+import static org.stellar.anchor.api.sep.sep24.InfoResponse.FeeResponse;
 import static org.stellar.anchor.event.EventService.EventQueue.TRANSACTION;
-import static org.stellar.anchor.sep24.Sep24Helper.*;
+import static org.stellar.anchor.sep24.Sep24Helper.setSharedTransactionResponseFields;
 import static org.stellar.anchor.sep24.Sep24Transaction.Kind.WITHDRAWAL;
-import static org.stellar.anchor.util.Log.*;
+import static org.stellar.anchor.util.Log.debug;
+import static org.stellar.anchor.util.Log.debugF;
+import static org.stellar.anchor.util.Log.info;
+import static org.stellar.anchor.util.Log.infoF;
+import static org.stellar.anchor.util.Log.shorter;
 import static org.stellar.anchor.util.MathHelper.decimal;
 import static org.stellar.anchor.util.MemoHelper.makeMemo;
 import static org.stellar.anchor.util.MemoHelper.memoType;
@@ -20,23 +25,44 @@ import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
 import org.stellar.anchor.api.event.AnchorEvent;
-import org.stellar.anchor.api.exception.*;
+import org.stellar.anchor.api.exception.AnchorException;
+import org.stellar.anchor.api.exception.SepException;
+import org.stellar.anchor.api.exception.SepNotAuthorizedException;
+import org.stellar.anchor.api.exception.SepNotFoundException;
+import org.stellar.anchor.api.exception.SepValidationException;
+import org.stellar.anchor.api.exception.rpc.InvalidParamsException;
 import org.stellar.anchor.api.sep.AssetInfo;
-import org.stellar.anchor.api.sep.sep24.*;
+import org.stellar.anchor.api.sep.sep24.DepositTransactionResponse;
+import org.stellar.anchor.api.sep.sep24.GetTransactionRequest;
+import org.stellar.anchor.api.sep.sep24.GetTransactionsRequest;
+import org.stellar.anchor.api.sep.sep24.GetTransactionsResponse;
+import org.stellar.anchor.api.sep.sep24.InfoResponse;
+import org.stellar.anchor.api.sep.sep24.InteractiveTransactionResponse;
+import org.stellar.anchor.api.sep.sep24.Sep24GetTransactionResponse;
+import org.stellar.anchor.api.sep.sep24.TransactionResponse;
+import org.stellar.anchor.api.sep.sep24.WithdrawTransactionResponse;
 import org.stellar.anchor.asset.AssetService;
 import org.stellar.anchor.auth.JwtService;
 import org.stellar.anchor.auth.Sep10Jwt;
 import org.stellar.anchor.config.AppConfig;
+import org.stellar.anchor.config.CustodyConfig;
 import org.stellar.anchor.config.Sep24Config;
 import org.stellar.anchor.event.EventService;
+import org.stellar.anchor.util.CustodyUtils;
 import org.stellar.anchor.util.GsonUtils;
 import org.stellar.anchor.util.TransactionHelper;
 import org.stellar.sdk.KeyPair;
 import org.stellar.sdk.Memo;
 
 public class Sep24Service {
+
   final AppConfig appConfig;
   final Sep24Config sep24Config;
   final AssetService assetService;
@@ -45,6 +71,7 @@ public class Sep24Service {
   final EventService.Session eventSession;
   final InteractiveUrlConstructor interactiveUrlConstructor;
   final MoreInfoUrlConstructor moreInfoUrlConstructor;
+  final CustodyConfig custodyConfig;
 
   static final Gson gson = GsonUtils.getInstance();
 
@@ -59,7 +86,8 @@ public class Sep24Service {
       Sep24TransactionStore txnStore,
       EventService eventService,
       InteractiveUrlConstructor interactiveUrlConstructor,
-      MoreInfoUrlConstructor moreInfoUrlConstructor) {
+      MoreInfoUrlConstructor moreInfoUrlConstructor,
+      CustodyConfig custodyConfig) {
     debug("appConfig:", appConfig);
     debug("sep24Config:", sep24Config);
     this.appConfig = appConfig;
@@ -70,6 +98,7 @@ public class Sep24Service {
     this.eventSession = eventService.createSession(this.getClass().getName(), TRANSACTION);
     this.interactiveUrlConstructor = interactiveUrlConstructor;
     this.moreInfoUrlConstructor = moreInfoUrlConstructor;
+    this.custodyConfig = custodyConfig;
     info("Sep24Service initialized.");
   }
 
@@ -171,12 +200,30 @@ public class Sep24Service {
     // TODO - jamie to look into memo vs withdrawal_memo
     if (memo != null) {
       debug("transaction memo detected.", memo);
+
+      if (!CustodyUtils.isMemoTypeSupported(
+          custodyConfig.getType(), memoTypeString(memoType(memo)))) {
+        throw new InvalidParamsException(
+            String.format(
+                "Memo type[%s] is not supported for custody type[%s]",
+                memoTypeString(memoType(memo)), custodyConfig.getType()));
+      }
+
       builder.memo(memo.toString());
       builder.memoType(memoTypeString(memoType(memo)));
     }
 
     if (refundMemo != null) {
       debug("refund memo detected.", refundMemo);
+
+      if (!CustodyUtils.isMemoTypeSupported(
+          custodyConfig.getType(), memoTypeString(memoType(refundMemo)))) {
+        throw new InvalidParamsException(
+            String.format(
+                "Refund memo type[%s] is not supported for custody type[%s]",
+                memoTypeString(memoType(refundMemo)), custodyConfig.getType()));
+      }
+
       builder.refundMemo(refundMemo.toString());
       builder.refundMemoType(memoTypeString(memoType(refundMemo)));
     }

--- a/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
+++ b/core/src/test/kotlin/org/stellar/anchor/sep24/Sep24ServiceTest.kt
@@ -40,6 +40,7 @@ import org.stellar.anchor.auth.JwtService.CLIENT_DOMAIN
 import org.stellar.anchor.auth.Sep10Jwt
 import org.stellar.anchor.auth.Sep24InteractiveUrlJwt
 import org.stellar.anchor.config.AppConfig
+import org.stellar.anchor.config.CustodyConfig
 import org.stellar.anchor.config.CustodySecretConfig
 import org.stellar.anchor.config.SecretConfig
 import org.stellar.anchor.config.Sep24Config
@@ -75,6 +76,8 @@ internal class Sep24ServiceTest {
 
   @MockK(relaxed = true) lateinit var moreInfoUrlConstructor: MoreInfoUrlConstructor
 
+  @MockK(relaxed = true) lateinit var custodyConfig: CustodyConfig
+
   private val assetService: AssetService = DefaultAssetService.fromJsonResource("test_assets.json")
 
   private lateinit var jwtService: JwtService
@@ -109,7 +112,8 @@ internal class Sep24ServiceTest {
         txnStore,
         eventService,
         interactiveUrlConstructor,
-        moreInfoUrlConstructor
+        moreInfoUrlConstructor,
+        custodyConfig
       )
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -162,7 +162,8 @@ public class SepBeans {
       Sep24TransactionStore sep24TransactionStore,
       EventService eventService,
       InteractiveUrlConstructor interactiveUrlConstructor,
-      MoreInfoUrlConstructor moreInfoUrlConstructor) {
+      MoreInfoUrlConstructor moreInfoUrlConstructor,
+      CustodyConfig custodyConfig) {
     return new Sep24Service(
         appConfig,
         sep24Config,
@@ -171,7 +172,8 @@ public class SepBeans {
         sep24TransactionStore,
         eventService,
         interactiveUrlConstructor,
-        moreInfoUrlConstructor);
+        moreInfoUrlConstructor,
+        custodyConfig);
   }
 
   @Bean


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Refund memo type validation for custody services

### Why

Some custody services, for example Fireblocks, may not support some memo types, for example `hash`

### Known limitations

[TODO or N/A]