### PR TITLE
SDFSOF-141: Observer: the status of sep31 transaction is not updated to pending_anchor/pending_received when the stellar transction with requested memo and amount completed on the network

### DIFF
--- a/api-schema/src/main/java/org/stellar/anchor/api/rpc/RpcErrorCode.java
+++ b/api-schema/src/main/java/org/stellar/anchor/api/rpc/RpcErrorCode.java
@@ -10,8 +10,7 @@ public enum RpcErrorCode {
   INVALID_REQUEST(-32600),
   METHOD_NOT_FOUND(-32601),
   INVALID_PARAMS(-32602),
-  INTERNAL_ERROR(-32603),
-  PARSE_ERROR(-32700);
+  INTERNAL_ERROR(-32603);
 
   private final int errorCode;
   private static final Map<Integer, RpcErrorCode> errorCodeMap;

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionRepo.java
@@ -19,7 +19,7 @@ public interface JdbcSep24TransactionRepo
 
   JdbcSep24Transaction findOneByStellarTransactionId(String stellarTransactionId);
 
-  JdbcSep24Transaction findOneBySep10AccountAndMemo(String accountId, String memo);
+  JdbcSep24Transaction findOneByToAccountAndMemo(String accountId, String memo);
 
   List<Sep24Transaction> findBySep10AccountAndRequestAssetCodeOrderByStartedAtDesc(
       String stellarAccount, String assetCode);

--- a/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/data/JdbcSep24TransactionStore.java
@@ -53,9 +53,9 @@ public class JdbcSep24TransactionStore implements Sep24TransactionStore {
     return txnRepo.findOneByExternalTransactionId(externalTransactionId);
   }
 
-  public JdbcSep24Transaction findByStellarAccountIdAndMemo(String accountId, String memo) {
+  public JdbcSep24Transaction findByToAccountAndMemo(String toAccount, String memo) {
     Optional<JdbcSep24Transaction> optTxn =
-        Optional.ofNullable(txnRepo.findOneBySep10AccountAndMemo(accountId, memo));
+        Optional.ofNullable(txnRepo.findOneByToAccountAndMemo(toAccount, memo));
     return optTxn.orElse(null);
   }
 

--- a/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/service/PaymentOperationToEventListener.java
@@ -76,8 +76,7 @@ public class PaymentOperationToEventListener implements PaymentListener {
     // Find a transaction matching the memo, assumes transactions are unique to account+memo
     JdbcSep31Transaction sep31Txn = null;
     try {
-      sep31Txn =
-          sep31TransactionStore.findByStellarAccountIdAndMemo(payment.getSourceAccount(), memo);
+      sep31Txn = sep31TransactionStore.findByStellarAccountIdAndMemo(payment.getTo(), memo);
     } catch (Exception ex) {
       errorEx(ex);
     }
@@ -95,8 +94,7 @@ public class PaymentOperationToEventListener implements PaymentListener {
     // Find a transaction matching the memo, assumes transactions are unique to account+memo
     JdbcSep24Transaction sep24Txn;
     try {
-      sep24Txn =
-          sep24TransactionStore.findByStellarAccountIdAndMemo(payment.getSourceAccount(), memo);
+      sep24Txn = sep24TransactionStore.findByToAccountAndMemo(payment.getTo(), memo);
     } catch (Exception ex) {
       errorEx(ex);
       return;

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/service/PaymentOperationToEventListenerTest.kt
@@ -84,7 +84,7 @@ class PaymentOperationToEventListenerTest {
     p.transactionHash = "1ad62e48724426be96cf2cdb65d5dacb8fac2e403e50bedb717bfc8eaf05af30"
     p.transactionMemo = "my_memo_2"
     p.assetType = "credit_alphanum4"
-    p.sourceAccount = "GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5"
+    p.to = "GBT7YF22QEVUDUTBUIS2OWLTZMP7Z4J4ON6DCSHR3JXYTZRKCPXVV5J5"
     p.amount = "1"
     p.assetName = "FOO:GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364"
     var slotMemo = slot<String>()
@@ -95,7 +95,7 @@ class PaymentOperationToEventListenerTest {
     val sep24Txn = JdbcSep24Transaction()
     sep24Txn.amountIn = "1"
     every {
-      sep24TransactionStore.findByStellarAccountIdAndMemo(capture(slotAccount), capture(slotMemo))
+      sep24TransactionStore.findByToAccountAndMemo(capture(slotAccount), capture(slotMemo))
     } returns sep24Txn
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
@@ -238,7 +238,7 @@ class PaymentOperationToEventListenerTest {
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
       sep31TransactionStore.findByStellarAccountIdAndMemo(
-        "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ="
       )
     }
@@ -308,7 +308,7 @@ class PaymentOperationToEventListenerTest {
     val sep31TxCopy = gson.fromJson(gson.toJson(sep31TxMock), JdbcSep31Transaction::class.java)
     every {
       sep31TransactionStore.findByStellarAccountIdAndMemo(
-        "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         capture(slotMemo)
       )
     } returns sep31TxCopy
@@ -331,7 +331,7 @@ class PaymentOperationToEventListenerTest {
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
       sep31TransactionStore.findByStellarAccountIdAndMemo(
-        "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ="
       )
     }
@@ -395,8 +395,8 @@ class PaymentOperationToEventListenerTest {
 
     val sep24TxnCopy = gson.fromJson(gson.toJson(sep24TxMock), JdbcSep24Transaction::class.java)
     every {
-      sep24TransactionStore.findByStellarAccountIdAndMemo(
-        "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
+      sep24TransactionStore.findByToAccountAndMemo(
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         capture(slotMemo)
       )
     } returns sep24TxnCopy
@@ -418,8 +418,8 @@ class PaymentOperationToEventListenerTest {
 
     paymentOperationToEventListener.onReceived(p)
     verify(exactly = 1) {
-      sep24TransactionStore.findByStellarAccountIdAndMemo(
-        "GCJKWN7ELKOXLDHJTOU4TZOEJQL7TYVVTQFR676MPHHUIUDAHUA7QGJ4",
+      sep24TransactionStore.findByToAccountAndMemo(
+        "GBZ4HPSEHKEEJ6MOZBSVV2B3LE27EZLV6LJY55G47V7BGBODWUXQM364",
         "OWI3OGYwZmEtOTNmOS00MTk4LThkOTMtZTc2ZmQwODQ="
       )
     }


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Find transaction by `toAccount` + `memo` combination to handle payment

### Why

`SEP-31` payments are not handled correctly

### Known limitations

[TODO or N/A]