### PR TITLE
SDFSOF-143: [Improvement] Custody integration: force memo generation strategy to custody if a custody service integration is enabled

### DIFF
--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24CustodyEnd2EndTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24CustodyEnd2EndTests.kt
@@ -65,7 +65,7 @@ class Sep24CustodyEnd2EndTests(config: TestConfig, val jwt: String) {
         socketTimeoutMillis = 300000
       }
     }
-  private val maxTries = 30
+  private val maxTries = 90
   private val anchorReferenceServerClient =
     AnchorReferenceServerClient(Url(config.env["reference.server.url"]!!))
   private val walletServerClient = WalletServerClient(Url(config.env["wallet.server.url"]!!))
@@ -152,6 +152,7 @@ class Sep24CustodyEnd2EndTests(config: TestConfig, val jwt: String) {
         expectedEvent.transaction.id = actualEvent.transaction.id
         expectedEvent.transaction.startedAt = actualEvent.transaction.startedAt
         expectedEvent.transaction.updatedAt = actualEvent.transaction.updatedAt
+        expectedEvent.transaction.completedAt = actualEvent.transaction.completedAt
         expectedEvent.transaction.stellarTransactions = actualEvent.transaction.stellarTransactions
         expectedEvent.transaction.memo = actualEvent.transaction.memo
         actualEvent.transaction.amountIn?.let {
@@ -481,169 +482,220 @@ class Sep24CustodyEnd2EndTests(config: TestConfig, val jwt: String) {
 
   private val expectedWithdrawEventJson =
     """
-    [
-      {
-        "type": "transaction_created",
-        "sep": "24",
-        "transaction": {
-          "sep": "24",
-          "kind": "withdrawal",
-          "status": "incomplete",
-          "amount_expected": {
-          },
-          "started_at": "2023-07-19T20:20:51.792908200Z",
-          "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
-        }
+[
+  {
+    "type": "transaction_created",
+    "id": "a32464b5-e4f2-4d85-955a-2f09696b3103",
+    "sep": "24",
+    "transaction": {
+      "id": "419d2cd3-1ebd-42fc-80c5-94fe506d144b",
+      "sep": "24",
+      "kind": "withdrawal",
+      "status": "incomplete",
+      "amount_expected": {
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
       },
-      {
-        "type": "transaction_status_changed",
-        "sep": "24",
-        "transaction": {
-          "sep": "24",
-          "kind": "withdrawal",
-          "status": "pending_user_transfer_start",
-          "amount_expected": {
-          },
-          "amount_in": {
-          },
-          "amount_out": {
-          },
-          "amount_fee": {
-          },
-          "message": "waiting on the user to transfer funds",
-          "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
-          "memo_type": "hash"
-        }
+      "started_at": "2023-08-30T09:48:08.715329Z",
+      "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+      "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+    }
+  },
+  {
+    "type": "transaction_status_changed",
+    "id": "0f454aa9-e328-4967-befe-b686410f6e54",
+    "sep": "24",
+    "transaction": {
+      "id": "419d2cd3-1ebd-42fc-80c5-94fe506d144b",
+      "sep": "24",
+      "kind": "withdrawal",
+      "status": "pending_user_transfer_start",
+      "amount_expected": {
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
       },
-      {
-        "type": "transaction_status_changed",
-        "id": "f0b75f9e-1b53-442a-91dd-d6c002a51bfc",
-        "sep": "24",
-        "transaction": {
-          "id": "14882409-757c-4c66-9da1-3dddef11953a",
-          "sep": "24",
-          "kind": "withdrawal",
-          "status": "pending_anchor",
-          "amount_expected": {
-          },
-          "amount_in": {
-          },
-          "amount_out": {
-          },
-          "amount_fee": {
-          },
-          "message": "Received an incoming payment",
-          "stellar_transactions": [
+      "amount_in": {
+        "amount": "1.1",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "amount_out": {
+        "amount": "1.0",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "amount_fee": {
+        "amount": "0.1",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "started_at": "2023-08-30T09:48:08.715329Z",
+      "updated_at": "2023-08-30T09:48:09.788551Z",
+      "message": "waiting on the user to transfer funds",
+      "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+      "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
+      "memo": "2653020630",
+      "memo_type": "id"
+    }
+  },
+  {
+    "type": "transaction_status_changed",
+    "id": "e8b7a043-7952-4803-8886-34c5fefa459a",
+    "sep": "24",
+    "transaction": {
+      "id": "419d2cd3-1ebd-42fc-80c5-94fe506d144b",
+      "sep": "24",
+      "kind": "withdrawal",
+      "status": "pending_anchor",
+      "amount_expected": {
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "amount_in": {
+        "amount": "1.1000000",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "amount_out": {
+        "amount": "1.0",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "amount_fee": {
+        "amount": "0.1",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "started_at": "2023-08-30T09:48:08.715329Z",
+      "updated_at": "2023-08-30T09:48:20.560738Z",
+      "message": "Received an incoming payment",
+      "stellar_transactions": [
+        {
+          "id": "979b540a85c84854980ed8378f333b470071ef34731e998a43a1272e0377c6b9",
+          "memo": "2653020630",
+          "memo_type": "id",
+          "created_at": "2023-08-30T09:48:13Z",
+          "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAASdQAAAAEAAAAAAAAAAAAAAABk7xEQAAAAAgAAAACeIeHWAAAAAQAAAAAAAAABAAAAAEGxI2xgj2aqGDYg25rygTOTzyLGOpz9iKrT/gw0MhwDAAAAAVVTREMAAAAAQj59BfLsr7/sGSshWj8b6WrtuNjnAlSr40E+AgfeVrIAAAAAAKfYwAAAAAAAAAABgRA+VQAAAECf6CEOtlF882R4A650Op2kf9MwYc7E9TrQdCyzU54Dr1dZHiA3h/Yf8/51En5MIngAs0ZkIiIwIy1zD3P0KxMO",
+          "payments": [
             {
-              "id": "9234bd186612f4d48cafed4c702509f680a581c3e02945f0206b4c8ac627b83a",
-              "memo": "MTQ4ODI0MDktNzU3Yy00YzY2LTlkYTEtM2RkZGVmMTE\u003d",
-              "memo_type": "hash",
-              "created_at": "2023-07-19T20:21:01Z",
-              "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAAGzgAAAAEAAAAAAAAAAAAAAABkuEZbAAAAAzE0ODgyNDA5LTc1N2MtNGM2Ni05ZGExLTNkZGRlZjExAAAAAQAAAAAAAAABAAAAAFvGtEMyXcvbioU2IKCSomxahpl7lUyef7ftEPxWcD4bAAAAAVVTREMAAAAA4OJrYiyoyVYK5jqTvfhX91wJp8nB8jVCrv7/SoR3rwAAAAAABfXhAAAAAAAAAAABgRA+VQAAAEDlmaoq46tJ7Lja9SP4BAuTl1GOrPuf7HAsK4JyNdhxkwz2p5U181Eq394rjIn/fr43lkgarA9m05Q04t4gHqkH",
-              "payments": [
-                {
-                  "id": "2504876466638849",
-                  "amount": {
-                  },
-                  "payment_type": "payment",
-                  "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-                  "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
-                }
-              ]
+              "id": "5439412871634945",
+              "amount": {
+                "amount": "1.1000000",
+                "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+              },
+              "payment_type": "payment",
+              "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+              "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6"
             }
-          ],
-          "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
-          "memo_type": "hash"
+          ]
         }
+      ],
+      "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+      "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
+      "memo": "2653020630",
+      "memo_type": "id"
+    }
+  },
+  {
+    "type": "transaction_status_changed",
+    "id": "91da8107-2916-44e5-a34b-5e533b31b8b6",
+    "sep": "24",
+    "transaction": {
+      "id": "419d2cd3-1ebd-42fc-80c5-94fe506d144b",
+      "sep": "24",
+      "kind": "withdrawal",
+      "status": "pending_external",
+      "amount_expected": {
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
       },
-      {
-        "type": "transaction_status_changed",
-        "id": "b44d90ec-2d9a-4768-a952-085026f5b3da",
-        "sep": "24",
-        "transaction": {
-          "id": "14882409-757c-4c66-9da1-3dddef11953a",
-          "sep": "24",
-          "kind": "withdrawal",
-          "status": "pending_external",
-          "amount_expected": {
-          },
-          "amount_in": {
-          },
-          "amount_out": {
-          },
-          "amount_fee": {
-          },
-          "message": "pending external transfer",
-          "stellar_transactions": [
-            {
-              "id": "9234bd186612f4d48cafed4c702509f680a581c3e02945f0206b4c8ac627b83a",
-              "memo": "MTQ4ODI0MDktNzU3Yy00YzY2LTlkYTEtM2RkZGVmMTE\u003d",
-              "memo_type": "hash",
-              "created_at": "2023-07-19T20:21:01Z",
-              "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAAGzgAAAAEAAAAAAAAAAAAAAABkuEZbAAAAAzE0ODgyNDA5LTc1N2MtNGM2Ni05ZGExLTNkZGRlZjExAAAAAQAAAAAAAAABAAAAAFvGtEMyXcvbioU2IKCSomxahpl7lUyef7ftEPxWcD4bAAAAAVVTREMAAAAA4OJrYiyoyVYK5jqTvfhX91wJp8nB8jVCrv7/SoR3rwAAAAAABfXhAAAAAAAAAAABgRA+VQAAAEDlmaoq46tJ7Lja9SP4BAuTl1GOrPuf7HAsK4JyNdhxkwz2p5U181Eq394rjIn/fr43lkgarA9m05Q04t4gHqkH",
-              "payments": [
-                {
-                  "id": "2504876466638849",
-                  "amount": {
-                  },
-                  "payment_type": "payment",
-                  "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-                  "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
-                }
-              ]
-            }
-          ],
-          "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
-          "memo_type": "hash"
-        }
+      "amount_in": {
+        "amount": "1.1000000",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
       },
-      {
-        "type": "transaction_status_changed",
-        "id": "0556b75c-b054-49a0-b778-654050a6cba4",
-        "sep": "24",
-        "transaction": {
-          "id": "14882409-757c-4c66-9da1-3dddef11953a",
-          "sep": "24",
-          "kind": "withdrawal",
-          "status": "completed",
-          "amount_expected": {
-          },
-          "amount_in": {
-          },
-          "amount_out": {
-          },
-          "amount_fee": {
-          },
-          "message": "Completed",
-          "stellar_transactions": [
+      "amount_out": {
+        "amount": "1.0",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "amount_fee": {
+        "amount": "0.1",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "started_at": "2023-08-30T09:48:08.715329Z",
+      "updated_at": "2023-08-30T09:48:26.429049Z",
+      "message": "pending external transfer",
+      "stellar_transactions": [
+        {
+          "id": "979b540a85c84854980ed8378f333b470071ef34731e998a43a1272e0377c6b9",
+          "memo": "2653020630",
+          "memo_type": "id",
+          "created_at": "2023-08-30T09:48:13Z",
+          "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAASdQAAAAEAAAAAAAAAAAAAAABk7xEQAAAAAgAAAACeIeHWAAAAAQAAAAAAAAABAAAAAEGxI2xgj2aqGDYg25rygTOTzyLGOpz9iKrT/gw0MhwDAAAAAVVTREMAAAAAQj59BfLsr7/sGSshWj8b6WrtuNjnAlSr40E+AgfeVrIAAAAAAKfYwAAAAAAAAAABgRA+VQAAAECf6CEOtlF882R4A650Op2kf9MwYc7E9TrQdCyzU54Dr1dZHiA3h/Yf8/51En5MIngAs0ZkIiIwIy1zD3P0KxMO",
+          "payments": [
             {
-              "id": "9234bd186612f4d48cafed4c702509f680a581c3e02945f0206b4c8ac627b83a",
-              "memo": "MTQ4ODI0MDktNzU3Yy00YzY2LTlkYTEtM2RkZGVmMTE\u003d",
-              "memo_type": "hash",
-              "created_at": "2023-07-19T20:21:01Z",
-              "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAAGzgAAAAEAAAAAAAAAAAAAAABkuEZbAAAAAzE0ODgyNDA5LTc1N2MtNGM2Ni05ZGExLTNkZGRlZjExAAAAAQAAAAAAAAABAAAAAFvGtEMyXcvbioU2IKCSomxahpl7lUyef7ftEPxWcD4bAAAAAVVTREMAAAAA4OJrYiyoyVYK5jqTvfhX91wJp8nB8jVCrv7/SoR3rwAAAAAABfXhAAAAAAAAAAABgRA+VQAAAEDlmaoq46tJ7Lja9SP4BAuTl1GOrPuf7HAsK4JyNdhxkwz2p5U181Eq394rjIn/fr43lkgarA9m05Q04t4gHqkH",
-              "payments": [
-                {
-                  "id": "2504876466638849",
-                  "amount": {
-                  },
-                  "payment_type": "payment",
-                  "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-                  "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
-                }
-              ]
+              "id": "5439412871634945",
+              "amount": {
+                "amount": "1.1000000",
+                "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+              },
+              "payment_type": "payment",
+              "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+              "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6"
             }
-          ],
-          "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-          "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
-          "memo_type": "hash"
+          ]
         }
-      }
-    ]
+      ],
+      "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+      "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
+      "memo": "2653020630",
+      "memo_type": "id"
+    }
+  },
+  {
+    "type": "transaction_status_changed",
+    "id": "ed653e12-e4ad-4cec-b71f-571855dfa1bb",
+    "sep": "24",
+    "transaction": {
+      "id": "419d2cd3-1ebd-42fc-80c5-94fe506d144b",
+      "sep": "24",
+      "kind": "withdrawal",
+      "status": "completed",
+      "amount_expected": {
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "amount_in": {
+        "amount": "1.1000000",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "amount_out": {
+        "amount": "1.0",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "amount_fee": {
+        "amount": "0.1",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "started_at": "2023-08-30T09:48:08.715329Z",
+      "updated_at": "2023-08-30T09:48:27.467368Z",
+      "message": "completed",
+      "stellar_transactions": [
+        {
+          "id": "979b540a85c84854980ed8378f333b470071ef34731e998a43a1272e0377c6b9",
+          "memo": "2653020630",
+          "memo_type": "id",
+          "created_at": "2023-08-30T09:48:13Z",
+          "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAASdQAAAAEAAAAAAAAAAAAAAABk7xEQAAAAAgAAAACeIeHWAAAAAQAAAAAAAAABAAAAAEGxI2xgj2aqGDYg25rygTOTzyLGOpz9iKrT/gw0MhwDAAAAAVVTREMAAAAAQj59BfLsr7/sGSshWj8b6WrtuNjnAlSr40E+AgfeVrIAAAAAAKfYwAAAAAAAAAABgRA+VQAAAECf6CEOtlF882R4A650Op2kf9MwYc7E9TrQdCyzU54Dr1dZHiA3h/Yf8/51En5MIngAs0ZkIiIwIy1zD3P0KxMO",
+          "payments": [
+            {
+              "id": "5439412871634945",
+              "amount": {
+                "amount": "1.1000000",
+                "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+              },
+              "payment_type": "payment",
+              "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+              "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6"
+            }
+          ]
+        }
+      ],
+      "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
+      "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
+      "memo": "2653020630",
+      "memo_type": "id"
+    }
+  }
+]
   """
       .trimIndent()
 
@@ -659,7 +711,7 @@ class Sep24CustodyEnd2EndTests(config: TestConfig, val jwt: String) {
       "started_at": "2023-08-03T09:20:44.557598Z",
       "refunded": false,
       "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-      "to": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+      "to": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6"
     }
   },
   {
@@ -678,7 +730,7 @@ class Sep24CustodyEnd2EndTests(config: TestConfig, val jwt: String) {
       "message": "waiting on the user to transfer funds",
       "refunded": false,
       "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-      "to": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+      "to": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6"
     }
   },
   {
@@ -698,7 +750,7 @@ class Sep24CustodyEnd2EndTests(config: TestConfig, val jwt: String) {
       "message": "waiting on the user to transfer funds",
       "refunded": false,
       "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-      "to": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+      "to": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6"
     }
   },
   {
@@ -718,7 +770,7 @@ class Sep24CustodyEnd2EndTests(config: TestConfig, val jwt: String) {
       "message": "pending external transfer",
       "refunded": false,
       "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-      "to": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+      "to": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6"
     }
   },
   {
@@ -738,7 +790,7 @@ class Sep24CustodyEnd2EndTests(config: TestConfig, val jwt: String) {
       "message": "Completed",
       "refunded": false,
       "from": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-      "to": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+      "to": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6"
     }
   }
 ]    

--- a/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24CustodyRpcEnd2EndTests.kt
+++ b/integration-tests/src/test/kotlin/org/stellar/anchor/platform/test/Sep24CustodyRpcEnd2EndTests.kt
@@ -65,7 +65,7 @@ class Sep24CustodyRpcEnd2EndTests(config: TestConfig, val jwt: String) {
         socketTimeoutMillis = 300000
       }
     }
-  private val maxTries = 30
+  private val maxTries = 90
   private val anchorReferenceServerClient =
     AnchorReferenceServerClient(Url(config.env["reference.server.url"]!!))
   private val walletServerClient = WalletServerClient(Url(config.env["wallet.server.url"]!!))
@@ -101,17 +101,17 @@ class Sep24CustodyRpcEnd2EndTests(config: TestConfig, val jwt: String) {
       assertEquals(fetchedTxn.id, transactionByStellarId.id)
 
       // Check the events sent to the reference server are recorded correctly
-      val actualEvents = waitForBusinessServerEvents(response.id, 4)
+      val actualEvents = waitForBusinessServerEvents(response.id, 5)
       assertNotNull(actualEvents)
-      actualEvents?.let { assertEquals(4, it.size) }
+      actualEvents?.let { assertEquals(5, it.size) }
       val expectedEvents: List<AnchorEvent> =
         gson.fromJson(expectedDepositEventsJson, object : TypeToken<List<AnchorEvent>>() {}.type)
       compareAndAssertEvents(asset, expectedEvents, actualEvents!!)
 
       // Check the callbacks sent to the wallet reference server are recorded correctly
-      val actualCallbacks = waitForWalletServerCallbacks(response.id, 4)
+      val actualCallbacks = waitForWalletServerCallbacks(response.id, 5)
       actualCallbacks?.let {
-        assertEquals(4, it.size)
+        assertEquals(5, it.size)
         val expectedCallbacks: List<Sep24GetTransactionResponse> =
           gson.fromJson(
             expectedDepositCallbacksJson,
@@ -383,26 +383,26 @@ class Sep24CustodyRpcEnd2EndTests(config: TestConfig, val jwt: String) {
 [
   {
     "type": "transaction_created",
-    "id": "60a7a212-e072-4c26-b224-d0418c4535f3",
+    "id": "069bd5fb-1411-4a31-9a09-7f7fc44de1a9",
     "sep": "24",
     "transaction": {
-      "id": "2a26c89f-feb1-4791-aba0-577cb9b157a5",
+      "id": "11b91ac1-cd1c-44bb-9f73-37c8463556b3",
       "sep": "24",
       "kind": "deposit",
       "status": "incomplete",
       "amount_expected": {
         "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
       },
-      "started_at": "2023-08-17T13:12:51.563498Z",
+      "started_at": "2023-08-30T09:28:53.150236Z",
       "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
     }
   },
   {
     "type": "transaction_status_changed",
-    "id": "b26f417f-1273-4fab-af81-5e1192edbdb5",
+    "id": "de083721-2925-48d6-ac8c-5d3402f0ac58",
     "sep": "24",
     "transaction": {
-      "id": "2a26c89f-feb1-4791-aba0-577cb9b157a5",
+      "id": "11b91ac1-cd1c-44bb-9f73-37c8463556b3",
       "sep": "24",
       "kind": "deposit",
       "status": "pending_user_transfer_start",
@@ -422,18 +422,18 @@ class Sep24CustodyRpcEnd2EndTests(config: TestConfig, val jwt: String) {
         "amount": "0.1",
         "asset": "iso4217:USD"
       },
-      "started_at": "2023-08-17T13:12:51.563498Z",
-      "updated_at": "2023-08-17T13:12:53.912336Z",
+      "started_at": "2023-08-30T09:28:53.150236Z",
+      "updated_at": "2023-08-30T09:28:55.009299Z",
       "message": "waiting on the user to transfer funds",
       "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
     }
   },
   {
     "type": "transaction_status_changed",
-    "id": "64eed340-e2c0-4604-98a3-a0068b4f821c",
+    "id": "b3ce2b5a-fdac-469d-9805-48520e74890a",
     "sep": "24",
     "transaction": {
-      "id": "2a26c89f-feb1-4791-aba0-577cb9b157a5",
+      "id": "11b91ac1-cd1c-44bb-9f73-37c8463556b3",
       "sep": "24",
       "kind": "deposit",
       "status": "pending_anchor",
@@ -453,18 +453,49 @@ class Sep24CustodyRpcEnd2EndTests(config: TestConfig, val jwt: String) {
         "amount": "0.1",
         "asset": "iso4217:USD"
       },
-      "started_at": "2023-08-17T13:12:51.563498Z",
-      "updated_at": "2023-08-17T13:12:55.131947Z",
+      "started_at": "2023-08-30T09:28:53.150236Z",
+      "updated_at": "2023-08-30T09:28:56.197214Z",
       "message": "funds received, transaction is being processed",
       "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
     }
   },
   {
     "type": "transaction_status_changed",
-    "id": "11a6427e-c37a-41a6-952f-87478e961bdd",
+    "id": "f086a1d2-6edd-4d00-a294-f925b38dba78",
     "sep": "24",
     "transaction": {
-      "id": "2a26c89f-feb1-4791-aba0-577cb9b157a5",
+      "id": "11b91ac1-cd1c-44bb-9f73-37c8463556b3",
+      "sep": "24",
+      "kind": "deposit",
+      "status": "pending_stellar",
+      "amount_expected": {
+        "amount": "1.1",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "amount_in": {
+        "amount": "1.1",
+        "asset": "iso4217:USD"
+      },
+      "amount_out": {
+        "amount": "1.0",
+        "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
+      },
+      "amount_fee": {
+        "amount": "0.1",
+        "asset": "iso4217:USD"
+      },
+      "started_at": "2023-08-30T09:28:53.150236Z",
+      "updated_at": "2023-08-30T09:28:59.880923Z",
+      "message": "funds received, transaction is being processed",
+      "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
+    }
+  },
+  {
+    "type": "transaction_status_changed",
+    "id": "9cdfd7ca-7bb0-4737-95db-d4c860e1b6d0",
+    "sep": "24",
+    "transaction": {
+      "id": "11b91ac1-cd1c-44bb-9f73-37c8463556b3",
       "sep": "24",
       "kind": "deposit",
       "status": "completed",
@@ -484,24 +515,24 @@ class Sep24CustodyRpcEnd2EndTests(config: TestConfig, val jwt: String) {
         "amount": "0.1",
         "asset": "iso4217:USD"
       },
-      "started_at": "2023-08-17T13:12:51.563498Z",
-      "updated_at": "2023-08-17T13:13:02.384539Z",
-      "completed_at": "2023-08-17T13:13:02.384542Z",
-      "message": "funds received, transaction is being processed",
+      "started_at": "2023-08-30T09:28:53.150236Z",
+      "updated_at": "2023-08-30T09:29:21.380622Z",
+      "completed_at": "2023-08-30T09:29:21.380626Z",
+      "message": "Outgoing payment sent",
       "stellar_transactions": [
         {
-          "id": "f2c2c98de19dad3d5b436fe7c3de279ed7495b81555e9364343a81746065820c",
-          "created_at": "2023-08-17T13:13:00Z",
-          "envelope": "AAAAAgAAAAACJQsPAYY4MkKbJBd8Wl742m73Fb648rWVhCuwCcbDzAAAAGQAACDKAAAgGQAAAAEAAAAAAAAAAAAAAABk3h0UAAAAAAAAAAEAAAAAAAAAAQAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAAFVU0RDAAAAAODia2IsqMlWCuY6k734V/dcCafJwfI1Qq7+/0qEd68AAAAAAACn2MAAAAAAAAAAAQnGw8wAAABAtFQn7/sdQ2z8qzWWGRcpNmL1SZEUCrT4Qu/N2Y6YQu7Sdi0UvOdcuKuSu8Li/2rQvlynIv7mOwYOUfB7FNe5Bg==",
+          "id": "8c3bde0d88ca72d41cf0e51a3731ebbcb7cb600ea480869c6a9c26d33f27fc9c",
+          "created_at": "2023-08-30T09:29:08Z",
+          "envelope": "AAAAAgAAAABBsSNsYI9mqhg2INua8oEzk88ixjqc/Yiq0/4MNDIcAwAPQkAAAcGcAAAEzgAAAAEAAAAAT+J/KQAAAABk7zYKAAAAAAAAAAEAAAAAAAAAAQAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAAFVU0RDAAAAAEI+fQXy7K+/7BkrIVo/G+lq7bjY5wJUq+NBPgIH3layAAAAAACYloAAAAAAAAAAATQyHAMAAABAGCA5DBPJJDRO+yQLgZv7XLe6HBL1z/nvGJmSUNF/PI5yNASJs+EoLZ8iZwIxQBmPrepv3sVEL0ThsfAAJ6CMAw==",
           "payments": [
             {
-              "id": "4531774612836353",
+              "id": "5438480863727617",
               "amount": {
-                "amount": "1.1000000",
+                "amount": "1.0000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
-              "source_account": "GABCKCYPAGDDQMSCTMSBO7C2L34NU3XXCW7LR4VVSWCCXMAJY3B4YCZP",
+              "source_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
               "destination_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG"
             }
           ]
@@ -520,27 +551,27 @@ class Sep24CustodyRpcEnd2EndTests(config: TestConfig, val jwt: String) {
 [
   {
     "type": "transaction_created",
-    "id": "6d477438-d3f4-475f-8829-67a6539f2874",
+    "id": "5849cdc4-69ba-4e24-a4b1-468650b698f3",
     "sep": "24",
     "transaction": {
-      "id": "9b282aa4-739e-4869-bd57-42e81e818c4e",
+      "id": "57d95405-714b-4db2-8990-6aabb6fdead4",
       "sep": "24",
       "kind": "withdrawal",
       "status": "incomplete",
       "amount_expected": {
         "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
       },
-      "started_at": "2023-08-17T13:26:43.082739Z",
+      "started_at": "2023-08-30T09:52:09.053994Z",
       "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
       "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
     }
   },
   {
     "type": "transaction_status_changed",
-    "id": "4c8a96e9-8b7c-4a81-afbf-1f326ca71f5c",
+    "id": "d635ab90-b028-4e75-9603-3cc46f61522f",
     "sep": "24",
     "transaction": {
-      "id": "9b282aa4-739e-4869-bd57-42e81e818c4e",
+      "id": "57d95405-714b-4db2-8990-6aabb6fdead4",
       "sep": "24",
       "kind": "withdrawal",
       "status": "pending_user_transfer_start",
@@ -560,21 +591,21 @@ class Sep24CustodyRpcEnd2EndTests(config: TestConfig, val jwt: String) {
         "amount": "0.1",
         "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
       },
-      "started_at": "2023-08-17T13:26:43.082739Z",
-      "updated_at": "2023-08-17T13:26:44.195093Z",
+      "started_at": "2023-08-30T09:52:09.053994Z",
+      "updated_at": "2023-08-30T09:52:10.721779Z",
       "message": "waiting on the user to transfer funds",
       "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-      "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
-      "memo": "OWIyODJhYTQtNzM5ZS00ODY5LWJkNTctNDJlODFlODE=",
-      "memo_type": "hash"
+      "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
+      "memo": "1153741388",
+      "memo_type": "id"
     }
   },
   {
     "type": "transaction_status_changed",
-    "id": "20a03e0a-40c7-4373-882e-441a15028235",
+    "id": "296f1655-606c-44c7-89b1-1a5c1b8b3fd4",
     "sep": "24",
     "transaction": {
-      "id": "9b282aa4-739e-4869-bd57-42e81e818c4e",
+      "id": "57d95405-714b-4db2-8990-6aabb6fdead4",
       "sep": "24",
       "kind": "withdrawal",
       "status": "pending_anchor",
@@ -594,42 +625,42 @@ class Sep24CustodyRpcEnd2EndTests(config: TestConfig, val jwt: String) {
         "amount": "0.1",
         "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
       },
-      "started_at": "2023-08-17T13:26:43.082739Z",
-      "updated_at": "2023-08-17T13:26:52.617769Z",
+      "started_at": "2023-08-30T09:52:09.053994Z",
+      "updated_at": "2023-08-30T09:52:27.415929Z",
       "message": "Received an incoming payment",
       "stellar_transactions": [
         {
-          "id": "2a24a78fb7291bdb40604b400e468323049936dff760c29ccea2ed9405bb29ab",
-          "memo": "OWIyODJhYTQtNzM5ZS00ODY5LWJkNTctNDJlODFlODE=",
-          "memo_type": "hash",
-          "created_at": "2023-08-17T13:26:50Z",
-          "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAAQHgAAAAEAAAAAAAAAAAAAAABk3iDLAAAAAzliMjgyYWE0LTczOWUtNDg2OS1iZDU3LTQyZTgxZTgxAAAAAQAAAAAAAAABAAAAAFvGtEMyXcvbioU2IKCSomxahpl7lUyef7ftEPxWcD4bAAAAAVVTREMAAAAA4OJrYiyoyVYK5jqTvfhX91wJp8nB8jVCrv7/SoR3rwAAAAAAAKfYwAAAAAAAAAABgRA+VQAAAEAYZttwln2aJ/jsodZlAnorwJXndd8f0BtsIdrvVdcNt8BM7lf45gnmebKh8GjETEbOd2bkQvPDp8KJexGp0G8M",
+          "id": "e37723397971490a1e18eba37b01cee3e41c7ae542ca5c978fecc3e7f943f571",
+          "memo": "1153741388",
+          "memo_type": "id",
+          "created_at": "2023-08-30T09:52:15Z",
+          "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAASdgAAAAEAAAAAAAAAAAAAAABk7xIBAAAAAgAAAABExLJMAAAAAQAAAAAAAAABAAAAAEGxI2xgj2aqGDYg25rygTOTzyLGOpz9iKrT/gw0MhwDAAAAAVVTREMAAAAAQj59BfLsr7/sGSshWj8b6WrtuNjnAlSr40E+AgfeVrIAAAAAAKfYwAAAAAAAAAABgRA+VQAAAEAc7YJuwnoJ9FHjg+9XiDLu2BHezEmQfjVscoty3JJmpLFbuF0nQMU5W7l7Q2J0wIyE0qgMsVHQBsan43XhwOcJ",
           "payments": [
             {
-              "id": "4532461807603713",
+              "id": "5439610440126465",
               "amount": {
                 "amount": "1.1000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
               "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-              "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+              "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6"
             }
           ]
         }
       ],
       "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-      "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
-      "memo": "OWIyODJhYTQtNzM5ZS00ODY5LWJkNTctNDJlODFlODE=",
-      "memo_type": "hash"
+      "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
+      "memo": "1153741388",
+      "memo_type": "id"
     }
   },
   {
     "type": "transaction_status_changed",
-    "id": "4e9a1449-6124-4feb-aac1-18a3bb5b49ba",
+    "id": "71fdfe0a-c0ab-4a56-be6c-86beb21bfde6",
     "sep": "24",
     "transaction": {
-      "id": "9b282aa4-739e-4869-bd57-42e81e818c4e",
+      "id": "57d95405-714b-4db2-8990-6aabb6fdead4",
       "sep": "24",
       "kind": "withdrawal",
       "status": "completed",
@@ -649,35 +680,35 @@ class Sep24CustodyRpcEnd2EndTests(config: TestConfig, val jwt: String) {
         "amount": "0.1",
         "asset": "stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
       },
-      "started_at": "2023-08-17T13:26:43.082739Z",
-      "updated_at": "2023-08-17T13:26:55.426864Z",
-      "completed_at": "2023-08-17T13:26:55.426865Z",
+      "started_at": "2023-08-30T09:52:09.053994Z",
+      "updated_at": "2023-08-30T09:52:31.892921Z",
+      "completed_at": "2023-08-30T09:52:31.892923Z",
       "message": "pending external transfer",
       "stellar_transactions": [
         {
-          "id": "2a24a78fb7291bdb40604b400e468323049936dff760c29ccea2ed9405bb29ab",
-          "memo": "OWIyODJhYTQtNzM5ZS00ODY5LWJkNTctNDJlODFlODE=",
-          "memo_type": "hash",
-          "created_at": "2023-08-17T13:26:50Z",
-          "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAAQHgAAAAEAAAAAAAAAAAAAAABk3iDLAAAAAzliMjgyYWE0LTczOWUtNDg2OS1iZDU3LTQyZTgxZTgxAAAAAQAAAAAAAAABAAAAAFvGtEMyXcvbioU2IKCSomxahpl7lUyef7ftEPxWcD4bAAAAAVVTREMAAAAA4OJrYiyoyVYK5jqTvfhX91wJp8nB8jVCrv7/SoR3rwAAAAAAAKfYwAAAAAAAAAABgRA+VQAAAEAYZttwln2aJ/jsodZlAnorwJXndd8f0BtsIdrvVdcNt8BM7lf45gnmebKh8GjETEbOd2bkQvPDp8KJexGp0G8M",
+          "id": "e37723397971490a1e18eba37b01cee3e41c7ae542ca5c978fecc3e7f943f571",
+          "memo": "1153741388",
+          "memo_type": "id",
+          "created_at": "2023-08-30T09:52:15Z",
+          "envelope": "AAAAAgAAAADSsOMKYK7a1aALie83F4GQDoBdHrW86UX2SYVygRA+VQAAAGQAABUwAAASdgAAAAEAAAAAAAAAAAAAAABk7xIBAAAAAgAAAABExLJMAAAAAQAAAAAAAAABAAAAAEGxI2xgj2aqGDYg25rygTOTzyLGOpz9iKrT/gw0MhwDAAAAAVVTREMAAAAAQj59BfLsr7/sGSshWj8b6WrtuNjnAlSr40E+AgfeVrIAAAAAAKfYwAAAAAAAAAABgRA+VQAAAEAc7YJuwnoJ9FHjg+9XiDLu2BHezEmQfjVscoty3JJmpLFbuF0nQMU5W7l7Q2J0wIyE0qgMsVHQBsan43XhwOcJ",
           "payments": [
             {
-              "id": "4532461807603713",
+              "id": "5439610440126465",
               "amount": {
                 "amount": "1.1000000",
                 "asset": "USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5"
               },
               "payment_type": "payment",
               "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-              "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF"
+              "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6"
             }
           ]
         }
       ],
       "source_account": "GDJLBYYKMCXNVVNABOE66NYXQGIA5AC5D223Z2KF6ZEYK4UBCA7FKLTG",
-      "destination_account": "GBN4NNCDGJO4XW4KQU3CBIESUJWFVBUZPOKUZHT7W7WRB7CWOA7BXVQF",
-      "memo": "OWIyODJhYTQtNzM5ZS00ODY5LWJkNTctNDJlODFlODE=",
-      "memo_type": "hash"
+      "destination_account": "GBA3CI3MMCHWNKQYGYQNXGXSQEZZHTZCYY5JZ7MIVLJ74DBUGIOAGNV6",
+      "memo": "1153741388",
+      "memo_type": "id"
     }
   }
 ]

--- a/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/component/sep/SepBeans.java
@@ -93,8 +93,8 @@ public class SepBeans {
 
   @Bean
   @ConfigurationProperties(prefix = "sep31")
-  Sep31Config sep31Config() {
-    return new PropertySep31Config();
+  Sep31Config sep31Config(CustodyConfig custodyConfig) {
+    return new PropertySep31Config(custodyConfig);
   }
 
   @Bean

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep24Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep24Config.java
@@ -1,5 +1,6 @@
 package org.stellar.anchor.platform.config;
 
+import static org.stellar.anchor.config.Sep24Config.DepositInfoGeneratorType.*;
 import static org.stellar.anchor.util.StringHelper.isEmpty;
 import static org.stellar.anchor.util.StringHelper.snakeToCamelCase;
 
@@ -85,6 +86,7 @@ public class PropertySep24Config implements Sep24Config, Validator {
       validateInteractiveUrlConfig(errors);
       validateMoreInfoUrlConfig(errors);
       validateFeaturesConfig(errors);
+      validateDepositInfoGeneratorType(errors);
     }
   }
 
@@ -184,6 +186,23 @@ public class PropertySep24Config implements Sep24Config, Validator {
             "sep24-features-claimable_balances-not-supported",
             "Custody service doesn't support sending deposit funds as claimable balances");
       }
+    }
+  }
+
+  void validateDepositInfoGeneratorType(Errors errors) {
+    if (custodyConfig.isCustodyIntegrationEnabled() && CUSTODY != depositInfoGeneratorType) {
+      errors.rejectValue(
+          "depositInfoGeneratorType",
+          "sep24-deposit-info-generator-type",
+          String.format(
+              "[%s] deposit info generator type is not supported when custody integration is enabled",
+              depositInfoGeneratorType.toString().toLowerCase()));
+    } else if (!custodyConfig.isCustodyIntegrationEnabled()
+        && CUSTODY == depositInfoGeneratorType) {
+      errors.rejectValue(
+          "depositInfoGeneratorType",
+          "sep24-deposit-info-generator-type",
+          "[custody] deposit info generator type is not supported when custody integration is disabled");
     }
   }
 }

--- a/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep31Config.java
+++ b/platform/src/main/java/org/stellar/anchor/platform/config/PropertySep31Config.java
@@ -1,16 +1,52 @@
 package org.stellar.anchor.platform.config;
 
-import static org.stellar.anchor.config.Sep31Config.DepositInfoGeneratorType.SELF;
+import static org.stellar.anchor.config.Sep31Config.DepositInfoGeneratorType.CUSTODY;
 import static org.stellar.anchor.config.Sep31Config.PaymentType.STRICT_SEND;
 
 import lombok.Data;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.validation.Errors;
+import org.springframework.validation.Validator;
+import org.stellar.anchor.config.CustodyConfig;
 import org.stellar.anchor.config.Sep31Config;
 
 @Data
-public class PropertySep31Config implements Sep31Config {
+public class PropertySep31Config implements Sep31Config, Validator {
   boolean enabled;
   PaymentType paymentType = STRICT_SEND;
-  DepositInfoGeneratorType depositInfoGeneratorType = SELF;
+  DepositInfoGeneratorType depositInfoGeneratorType;
+  CustodyConfig custodyConfig;
 
-  public PropertySep31Config() {}
+  public PropertySep31Config(CustodyConfig custodyConfig) {
+    this.custodyConfig = custodyConfig;
+  }
+
+  @Override
+  public boolean supports(@NotNull Class<?> clazz) {
+    return Sep31Config.class.isAssignableFrom(clazz);
+  }
+
+  @Override
+  public void validate(@NotNull Object target, @NotNull Errors errors) {
+    if (enabled) {
+      validateDepositInfoGeneratorType(errors);
+    }
+  }
+
+  void validateDepositInfoGeneratorType(Errors errors) {
+    if (custodyConfig.isCustodyIntegrationEnabled() && CUSTODY != depositInfoGeneratorType) {
+      errors.rejectValue(
+          "depositInfoGeneratorType",
+          "sep31-deposit-info-generator-type",
+          String.format(
+              "[%s] deposit info generator type is not supported when custody integration is enabled",
+              depositInfoGeneratorType.toString().toLowerCase()));
+    } else if (!custodyConfig.isCustodyIntegrationEnabled()
+        && CUSTODY == depositInfoGeneratorType) {
+      errors.rejectValue(
+          "depositInfoGeneratorType",
+          "sep31-deposit-info-generator-type",
+          "[custody] deposit info generator type is not supported when custody integration is disabled");
+    }
+  }
 }

--- a/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep31ConfigTest.kt
+++ b/platform/src/test/kotlin/org/stellar/anchor/platform/config/Sep31ConfigTest.kt
@@ -1,0 +1,57 @@
+package org.stellar.anchor.platform.config
+
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.validation.BindException
+import org.springframework.validation.Errors
+import org.stellar.anchor.config.CustodyConfig
+import org.stellar.anchor.config.Sep31Config.DepositInfoGeneratorType
+
+class Sep31ConfigTest {
+  lateinit var config: PropertySep31Config
+  lateinit var errors: Errors
+  lateinit var custodyConfig: CustodyConfig
+
+  @BeforeEach
+  fun setUp() {
+    custodyConfig = mockk()
+    every { custodyConfig.isCustodyIntegrationEnabled } returns false
+
+    config = PropertySep31Config(custodyConfig)
+    config.enabled = true
+    errors = BindException(config, "config")
+    config.depositInfoGeneratorType = DepositInfoGeneratorType.SELF
+  }
+
+  @Test
+  fun `test valid sep24 configuration`() {
+    config.validate(config, errors)
+    assertFalse(errors.hasErrors())
+  }
+
+  @Test
+  fun `test invalid deposit info generator type`() {
+    config.depositInfoGeneratorType = DepositInfoGeneratorType.CUSTODY
+    config.validate(config, errors)
+    assertEquals("sep31-deposit-info-generator-type", errors.allErrors[0].code)
+  }
+
+  @Test
+  fun `test valid sep24 configuration with custody integration`() {
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+    config.depositInfoGeneratorType = DepositInfoGeneratorType.CUSTODY
+    config.validate(config, errors)
+    assertFalse(errors.hasErrors())
+  }
+
+  @Test
+  fun `test invalid deposit info generator type with custody integration`() {
+    every { custodyConfig.isCustodyIntegrationEnabled } returns true
+    config.validate(config, errors)
+    assertEquals("sep31-deposit-info-generator-type", errors.allErrors[0].code)
+  }
+}

--- a/service-runner/src/main/resources/profiles/sep24-custody-rpc/config.env
+++ b/service-runner/src/main/resources/profiles/sep24-custody-rpc/config.env
@@ -39,6 +39,7 @@ sep24.enabled=true
 sep24.deposit_info_generator_type=custody
 sep24.interactive_url.base_url=http://localhost:8091/sep24/interactive
 sep24.more_info_url.base_url=http://localhost:8080/sep24/transaction/more_info
+sep31.deposit_info_generator_type=custody
 custody.type=fireblocks
 custody.fireblocks.public_key=MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAIXYulTJFC2wv+B1ZYnnfyS44+h/rGhcoyJZtHGu0DdZPfjmYebz+pbefoIEovSQ8g7zwIfVqQNtOjNNrhK4eBcCAwEAAQ==
 custody.fireblocks.asset_mappings=XLM_USDC_T_CEKS stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5\nXLM_TEST stellar:native

--- a/service-runner/src/main/resources/profiles/sep24-custody/config.env
+++ b/service-runner/src/main/resources/profiles/sep24-custody/config.env
@@ -41,6 +41,7 @@ sep24.enabled=true
 sep24.deposit_info_generator_type=custody
 sep24.interactive_url.base_url=http://localhost:8091/sep24/interactive
 sep24.more_info_url.base_url=http://localhost:8080/sep24/transaction/more_info
+sep31.deposit_info_generator_type=custody
 custody.type=fireblocks
 custody.fireblocks.public_key=MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAIXYulTJFC2wv+B1ZYnnfyS44+h/rGhcoyJZtHGu0DdZPfjmYebz+pbefoIEovSQ8g7zwIfVqQNtOjNNrhK4eBcCAwEAAQ==
 custody.fireblocks.asset_mappings=XLM_USDC_T_CEKS stellar:USDC:GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5\nXLM_TEST stellar:native


### PR DESCRIPTION
<!-- If you're making a doc PR or something tiny where the below is irrelevant, delete this
template and use a short description, but in your description aim to include both what the
change is, and why it is being made, with enough context for anyone to understand. -->

<details>
  <summary>PR Checklist</summary>

### PR Structure

* [ ] This PR has reasonably narrow scope (if not, break it down into smaller PRs).
* [ ] This PR avoids mixing refactoring changes with feature changes (split into two PRs
  otherwise).
* [ ] This PR's title starts with name of package that is most changed in the PR, ex.
  `paymentservice.stellar`, or `all` or `doc` if the changes are broad or impact many
  packages.

### Thoroughness

* [ ] This PR adds tests for the most critical parts of the new functionality or fixes.
</details>

### What

Validation for deposit info generator type

### Why

If custody integration is enabled, then only `custody` type should be available.
If custody integration is disabled, then `custody` type should be not available.

### Known limitations

[TODO or N/A]